### PR TITLE
Updated docker-compose.app.yml to include InfluxDB

### DIFF
--- a/.env.app
+++ b/.env.app
@@ -5,6 +5,8 @@ MOSQUITTO_VERSION=2.0.18
 # Porty zewnętrzne
 # ==========================================
 MQTT_PORT=1883
+INFLUX_DB_PORT=8181
+INFLUX_EXPLORER_PORT=8282
 
 # ==========================================
 # Konfiguracja sieci

--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -16,9 +16,57 @@ services:
     networks:
       - app_network
 
+  influxdb3-init:
+    image: busybox
+    container_name: iot_influxdb3-init
+    user: "0:0"
+    volumes:
+      - influx_data:/var/lib/influxdb3/data
+      - influx_plugins:/var/lib/influxdb3/plugins
+    command: >
+      sh -c "chown -R 1000:1000 /var/lib/influxdb3/data /var/lib/influxdb3/plugins"
+
+  influxdb3-core:
+    container_name: iot_influxdb3-core
+    image: 'influxdb:3-core'
+    ports:
+      - '${INFLUX_DB_PORT}:8181'
+    command:
+      - influxdb3
+      - serve
+      - '--node-id=node0'
+      - '--object-store=file'
+      - '--data-dir=/var/lib/influxdb3/data'
+      - '--plugin-dir=/var/lib/influxdb3/plugins'
+    volumes:
+      - influx_data:/var/lib/influxdb3/data
+      - influx_plugins:/var/lib/influxdb3/plugins
+    networks:
+      - app_network
+    user: "1000:1000"
+    depends_on:
+      influxdb3-init:
+        condition: service_completed_successfully
+
+  influxdb3-explorer:
+    container_name: iot_influxdb3-explorer
+    image: 'influxdata/influxdb3-ui:1.8.0'
+    ports:
+      - '${INFLUX_EXPLORER_PORT}:8080'
+    volumes:
+        - explorer_db:/db
+        - explorer_config:/app-root/config
+    networks:
+      - app_network
+    command: [ "--mode=admin" ]
+
 volumes:
   mosquitto_data:
   mosquitto_log:
+  influx_data:
+  influx_plugins:
+  explorer_db:
+  explorer_config:
 
 networks:
   app_network:


### PR DESCRIPTION
Dear lord please end my suffering

InfluxDB3 usage instructions after running the Docker Compose file:

1. Run the following command: `docker exec iot_influxdb3-core influxdb3 create token --admin`
2. Copy the newly created token and store it somewhere safe
3. Open `localhost:8282` to open the InfluxDB Explorer admin panel
4. Add the server: host is `influxdb3-core:8181`, use the token from earlier
5. Create a new database, for example `espdb`
6. Create a new table in said database, for example `lock`
7. The table should have the following config to work with Spring Boot correctly: `lockState int64 field` and a `deviceId tag`